### PR TITLE
Restrict yq bump automation to versioned release tags only.

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,4 +1,4 @@
-# bump: yq-version /YQ_VERSION="(.*)"/ https://github.com/mikefarah/yq.git|semver:^4
+# bump: yq-version /YQ_VERSION="(.*)"/ https://github.com/mikefarah/yq.git|semver:^v4
 YQ_VERSION="4.53.2"
 
 export ZOPEN_BUILD_LINE="STABLE"


### PR DESCRIPTION
The existing bump rule:

# bump: yq-version /YQ_VERSION="(.*)"/ https://github.com/mikefarah/yq.git|semver:^4

was incorrectly matching draft tags such as:

draft-4.53.3

and interpreting them as valid semver releases (4.53.3).

This caused the automation to generate:

YQ_VERSION="4.53.3"
export ZOPEN_STABLE_TAG="v${YQ_VERSION}"

which later failed during clone because upstream does not contain an actual v4.53.3 tag.

Updated the bump rule to:

# bump: yq-version /YQ_VERSION="(.*)"/ https://github.com/mikefarah/yq.git|semver:^v4

so only official release tags prefixed with v are considered.